### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.HotkeyIndicator.props
+++ b/props/LiveSplit.HotkeyIndicator.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.HotkeyIndicator.props
+++ b/props/LiveSplit.HotkeyIndicator.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
@@ -113,5 +113,8 @@ public class HotkeyIndicator : IComponent
     {
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
@@ -1,117 +1,117 @@
-﻿using LiveSplit.Model;
-using LiveSplit.UI;
-using LiveSplit.UI.Components;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
-namespace LiveSplit
+using LiveSplit.Model;
+using LiveSplit.UI;
+using LiveSplit.UI.Components;
+
+namespace LiveSplit;
+
+public class HotkeyIndicator : IComponent
 {
-    public class HotkeyIndicator : IComponent
+    public float PaddingTop => 0f;
+    public float PaddingLeft => 0f;
+    public float PaddingBottom => 0f;
+    public float PaddingRight => 0f;
+
+    protected LineComponent Line { get; set; }
+
+    public Color CurrentColor { get; set; }
+
+    public HotkeyIndicatorSettings Settings { get; set; }
+
+    public GraphicsCache Cache { get; set; }
+
+    public float VerticalHeight => Settings.IndicatorHeight;
+
+    public float MinimumWidth => 0f;
+
+    public float HorizontalWidth => Settings.IndicatorWidth;
+
+    public float MinimumHeight => 0f;
+
+    public HotkeyIndicator()
     {
-        public float PaddingTop => 0f;
-        public float PaddingLeft => 0f;
-        public float PaddingBottom => 0f;
-        public float PaddingRight => 0f;
-
-        protected LineComponent Line { get; set; }
-
-        public Color CurrentColor { get; set; }
-
-        public HotkeyIndicatorSettings Settings { get; set; }
-
-        public GraphicsCache Cache { get; set; }
-
-        public float VerticalHeight => Settings.IndicatorHeight;
-
-        public float MinimumWidth => 0f;
-
-        public float HorizontalWidth => Settings.IndicatorWidth;
-
-        public float MinimumHeight => 0f;
-
-        public HotkeyIndicator()
-        {
-            Line = new LineComponent(3, Color.White);
-            Cache = new GraphicsCache();
-            Settings = new HotkeyIndicatorSettings();
-        }
-
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
-        {
-            var oldClip = g.Clip;
-            var oldMatrix = g.Transform;
-            var oldMode = g.SmoothingMode;
-            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
-            g.Clip = new Region();
-            Line.LineColor = CurrentColor;
-            var scale = g.Transform.Elements.First();
-            var newHeight = Math.Max((int)(Settings.IndicatorHeight * scale + 0.5f), 1) / scale;
-            Line.VerticalHeight = newHeight;
-            g.TranslateTransform(0, (Settings.IndicatorHeight - newHeight) / 2f);
-            Line.DrawVertical(g, state, width, clipRegion);
-            g.Clip = oldClip;
-            g.Transform = oldMatrix;
-            g.SmoothingMode = oldMode;
-        }
-
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
-        {
-            var oldClip = g.Clip;
-            var oldMatrix = g.Transform;
-            var oldMode = g.SmoothingMode;
-            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
-            g.Clip = new Region();
-            Line.LineColor = CurrentColor;
-            var scale = g.Transform.Elements.First();
-            var newWidth = Math.Max((int)(Settings.IndicatorWidth * scale + 0.5f), 1) / scale;
-            g.TranslateTransform((Settings.IndicatorWidth - newWidth) / 2f, 0);
-            Line.HorizontalWidth = newWidth;
-            Line.DrawHorizontal(g, state, height, clipRegion);
-            g.Clip = oldClip;
-            g.Transform = oldMatrix;
-            g.SmoothingMode = oldMode;
-        }
-
-        public string ComponentName => "Hotkey Indicator";
-
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            Settings.Mode = mode;
-            return Settings;
-        }
-
-        public void SetSettings(System.Xml.XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-
-        public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        
-        public IDictionary<string, Action> ContextMenuControls => null;
-
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            CurrentColor = state.Settings.HotkeyProfiles[state.CurrentHotkeyProfile].GlobalHotkeysEnabled ? Settings.HotkeysOnColor : Settings.HotkeysOffColor;
-
-            Cache.Restart();
-            Cache["IndicatorColor"] = CurrentColor.ToArgb();
-
-            if (invalidator != null && Cache.HasChanged)
-                invalidator.Invalidate(0, 0, width, height);
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+        Line = new LineComponent(3, Color.White);
+        Cache = new GraphicsCache();
+        Settings = new HotkeyIndicatorSettings();
     }
+
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+    {
+        var oldClip = g.Clip;
+        var oldMatrix = g.Transform;
+        var oldMode = g.SmoothingMode;
+        g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
+        g.Clip = new Region();
+        Line.LineColor = CurrentColor;
+        var scale = g.Transform.Elements.First();
+        var newHeight = Math.Max((int)(Settings.IndicatorHeight * scale + 0.5f), 1) / scale;
+        Line.VerticalHeight = newHeight;
+        g.TranslateTransform(0, (Settings.IndicatorHeight - newHeight) / 2f);
+        Line.DrawVertical(g, state, width, clipRegion);
+        g.Clip = oldClip;
+        g.Transform = oldMatrix;
+        g.SmoothingMode = oldMode;
+    }
+
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
+    {
+        var oldClip = g.Clip;
+        var oldMatrix = g.Transform;
+        var oldMode = g.SmoothingMode;
+        g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
+        g.Clip = new Region();
+        Line.LineColor = CurrentColor;
+        var scale = g.Transform.Elements.First();
+        var newWidth = Math.Max((int)(Settings.IndicatorWidth * scale + 0.5f), 1) / scale;
+        g.TranslateTransform((Settings.IndicatorWidth - newWidth) / 2f, 0);
+        Line.HorizontalWidth = newWidth;
+        Line.DrawHorizontal(g, state, height, clipRegion);
+        g.Clip = oldClip;
+        g.Transform = oldMatrix;
+        g.SmoothingMode = oldMode;
+    }
+
+    public string ComponentName => "Hotkey Indicator";
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
+
+    public void SetSettings(System.Xml.XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+
+    public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        CurrentColor = state.Settings.HotkeyProfiles[state.CurrentHotkeyProfile].GlobalHotkeysEnabled ? Settings.HotkeysOnColor : Settings.HotkeysOffColor;
+
+        Cache.Restart();
+        Cache["IndicatorColor"] = CurrentColor.ToArgb();
+
+        if (invalidator != null && Cache.HasChanged)
+            invalidator.Invalidate(0, 0, width, height);
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
@@ -49,7 +49,7 @@ public class HotkeyIndicator : IComponent
         g.Clip = new Region();
         Line.LineColor = CurrentColor;
         var scale = g.Transform.Elements.First();
-        var newHeight = Math.Max((int)(Settings.IndicatorHeight * scale + 0.5f), 1) / scale;
+        var newHeight = Math.Max((int)((Settings.IndicatorHeight * scale) + 0.5f), 1) / scale;
         Line.VerticalHeight = newHeight;
         g.TranslateTransform(0, (Settings.IndicatorHeight - newHeight) / 2f);
         Line.DrawVertical(g, state, width, clipRegion);
@@ -67,7 +67,7 @@ public class HotkeyIndicator : IComponent
         g.Clip = new Region();
         Line.LineColor = CurrentColor;
         var scale = g.Transform.Elements.First();
-        var newWidth = Math.Max((int)(Settings.IndicatorWidth * scale + 0.5f), 1) / scale;
+        var newWidth = Math.Max((int)((Settings.IndicatorWidth * scale) + 0.5f), 1) / scale;
         g.TranslateTransform((Settings.IndicatorWidth - newWidth) / 2f, 0);
         Line.HorizontalWidth = newWidth;
         Line.DrawHorizontal(g, state, height, clipRegion);
@@ -89,12 +89,10 @@ public class HotkeyIndicator : IComponent
         Settings.SetSettings(settings);
     }
 
-
     public System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
     {
         return Settings.GetSettings(document);
     }
-
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
@@ -106,7 +104,9 @@ public class HotkeyIndicator : IComponent
         Cache["IndicatorColor"] = CurrentColor.ToArgb();
 
         if (invalidator != null && Cache.HasChanged)
+        {
             invalidator.Invalidate(0, 0, width, height);
+        }
     }
 
     public void Dispose()

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicator.cs
@@ -42,14 +42,14 @@ public class HotkeyIndicator : IComponent
 
     public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
     {
-        var oldClip = g.Clip;
-        var oldMatrix = g.Transform;
-        var oldMode = g.SmoothingMode;
+        Region oldClip = g.Clip;
+        System.Drawing.Drawing2D.Matrix oldMatrix = g.Transform;
+        System.Drawing.Drawing2D.SmoothingMode oldMode = g.SmoothingMode;
         g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
         g.Clip = new Region();
         Line.LineColor = CurrentColor;
-        var scale = g.Transform.Elements.First();
-        var newHeight = Math.Max((int)((Settings.IndicatorHeight * scale) + 0.5f), 1) / scale;
+        float scale = g.Transform.Elements.First();
+        float newHeight = Math.Max((int)((Settings.IndicatorHeight * scale) + 0.5f), 1) / scale;
         Line.VerticalHeight = newHeight;
         g.TranslateTransform(0, (Settings.IndicatorHeight - newHeight) / 2f);
         Line.DrawVertical(g, state, width, clipRegion);
@@ -60,14 +60,14 @@ public class HotkeyIndicator : IComponent
 
     public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
     {
-        var oldClip = g.Clip;
-        var oldMatrix = g.Transform;
-        var oldMode = g.SmoothingMode;
+        Region oldClip = g.Clip;
+        System.Drawing.Drawing2D.Matrix oldMatrix = g.Transform;
+        System.Drawing.Drawing2D.SmoothingMode oldMode = g.SmoothingMode;
         g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.Default;
         g.Clip = new Region();
         Line.LineColor = CurrentColor;
-        var scale = g.Transform.Elements.First();
-        var newWidth = Math.Max((int)((Settings.IndicatorWidth * scale) + 0.5f), 1) / scale;
+        float scale = g.Transform.Elements.First();
+        float newWidth = Math.Max((int)((Settings.IndicatorWidth * scale) + 0.5f), 1) / scale;
         g.TranslateTransform((Settings.IndicatorWidth - newWidth) / 2f, 0);
         Line.HorizontalWidth = newWidth;
         Line.DrawHorizontal(g, state, height, clipRegion);

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorFactory.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorFactory.cs
@@ -15,7 +15,10 @@ public class HotkeyIndicatorFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Other;
 
-    public IComponent Create(LiveSplitState state) => new HotkeyIndicator();
+    public IComponent Create(LiveSplitState state)
+    {
+        return new HotkeyIndicator();
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorFactory.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(HotkeyIndicatorFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class HotkeyIndicatorFactory : IComponentFactory
 {
-    public class HotkeyIndicatorFactory : IComponentFactory
-    {
-        public string ComponentName => "Hotkey Indicator";
+    public string ComponentName => "Hotkey Indicator";
 
-        public string Description => "Shows whether global hotkeys are on or off. Green indicates that global hotkeys are on, while red indicates off.";
+    public string Description => "Shows whether global hotkeys are on or off. Green indicates that global hotkeys are on, while red indicates off.";
 
-        public ComponentCategory Category => ComponentCategory.Other;
+    public ComponentCategory Category => ComponentCategory.Other;
 
-        public IComponent Create(LiveSplitState state) => new HotkeyIndicator();
+    public IComponent Create(LiveSplitState state) => new HotkeyIndicator();
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.HotkeyIndicator.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.HotkeyIndicator.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
@@ -3,88 +3,87 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class HotkeyIndicatorSettings : UserControl
 {
-    public partial class HotkeyIndicatorSettings : UserControl
+    public float IndicatorHeight { get; set; }
+    public float IndicatorWidth { get; set; }
+    public LayoutMode Mode { get; set; }
+    public Color HotkeysOnColor { get; set; }
+    public Color HotkeysOffColor { get; set; }
+    public GradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public float IndicatorHeight { get; set; }
-        public float IndicatorWidth { get; set; }
-        public LayoutMode Mode { get; set; }
-        public Color HotkeysOnColor { get; set; }
-        public Color HotkeysOffColor { get; set; }
-        public GradientType BackgroundGradient { get; set; }
-        public string GradientString
+        get { return BackgroundGradient.ToString(); }
+        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+    }
+
+    public HotkeyIndicatorSettings()
+    {
+        InitializeComponent();
+
+        IndicatorHeight = 3f;
+        IndicatorWidth = 3f;
+
+        HotkeysOnColor = Color.FromArgb(41, 204, 84);
+        HotkeysOffColor = Color.FromArgb(204, 55, 41);
+
+        btnColor1.DataBindings.Add("BackColor", this, "HotkeysOnColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "HotkeysOffColor", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
+
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        IndicatorHeight = SettingsHelper.ParseFloat(element["IndicatorHeight"], 3f);
+        IndicatorWidth = SettingsHelper.ParseFloat(element["IndicatorWidth"], 3f);
+        HotkeysOnColor = SettingsHelper.ParseColor(element["HotkeysOnColor"]);
+        HotkeysOffColor = SettingsHelper.ParseColor(element["HotkeysOffColor"]);
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
+
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
+
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "HotkeysOnColor", HotkeysOnColor) ^
+        SettingsHelper.CreateSetting(document, parent, "HotkeysOffColor", HotkeysOffColor) ^
+        SettingsHelper.CreateSetting(document, parent, "IndicatorHeight", IndicatorHeight) ^
+        SettingsHelper.CreateSetting(document, parent, "IndicatorWidth", IndicatorWidth);
+    }
+
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
+    }
+
+    private void HotkeyIndicatorSettings_Load(object sender, EventArgs e)
+    {
+        if (Mode == LayoutMode.Horizontal)
         {
-            get { return BackgroundGradient.ToString(); }
-            set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+            trkSize.DataBindings.Clear();
+            trkSize.Minimum = 1;
+            trkSize.Maximum = 50;
+            trkSize.DataBindings.Add("Value", this, "IndicatorWidth", false, DataSourceUpdateMode.OnPropertyChanged);
+            lblSize.Text = "Width:";
         }
-
-        public HotkeyIndicatorSettings()
+        else
         {
-            InitializeComponent();
-
-            IndicatorHeight = 3f;
-            IndicatorWidth = 3f;
-
-            HotkeysOnColor = Color.FromArgb(41, 204, 84);
-            HotkeysOffColor = Color.FromArgb(204, 55, 41);
-
-            btnColor1.DataBindings.Add("BackColor", this, "HotkeysOnColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "HotkeysOffColor", false, DataSourceUpdateMode.OnPropertyChanged);
-        }
-
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            IndicatorHeight = SettingsHelper.ParseFloat(element["IndicatorHeight"], 3f);
-            IndicatorWidth = SettingsHelper.ParseFloat(element["IndicatorWidth"], 3f);
-            HotkeysOnColor = SettingsHelper.ParseColor(element["HotkeysOnColor"]);
-            HotkeysOffColor = SettingsHelper.ParseColor(element["HotkeysOffColor"]);
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
-
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
-
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "HotkeysOnColor", HotkeysOnColor) ^
-            SettingsHelper.CreateSetting(document, parent, "HotkeysOffColor", HotkeysOffColor) ^
-            SettingsHelper.CreateSetting(document, parent, "IndicatorHeight", IndicatorHeight) ^
-            SettingsHelper.CreateSetting(document, parent, "IndicatorWidth", IndicatorWidth);
-        }
-
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
-
-        private void HotkeyIndicatorSettings_Load(object sender, EventArgs e)
-        {
-            if (Mode == LayoutMode.Horizontal)
-            {
-                trkSize.DataBindings.Clear();
-                trkSize.Minimum = 1;
-                trkSize.Maximum = 50;
-                trkSize.DataBindings.Add("Value", this, "IndicatorWidth", false, DataSourceUpdateMode.OnPropertyChanged);
-                lblSize.Text = "Width:";
-            }
-            else
-            {
-                trkSize.DataBindings.Clear();
-                trkSize.Minimum = 1;
-                trkSize.Maximum = 50;
-                trkSize.DataBindings.Add("Value", this, "IndicatorHeight", false, DataSourceUpdateMode.OnPropertyChanged);
-                lblSize.Text = "Height:";
-            }
+            trkSize.DataBindings.Clear();
+            trkSize.Minimum = 1;
+            trkSize.Maximum = 50;
+            trkSize.DataBindings.Add("Value", this, "IndicatorHeight", false, DataSourceUpdateMode.OnPropertyChanged);
+            lblSize.Text = "Height:";
         }
     }
 }

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
@@ -15,8 +15,8 @@ public partial class HotkeyIndicatorSettings : UserControl
     public GradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return BackgroundGradient.ToString(); }
-        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+        get => BackgroundGradient.ToString();
+        set => BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value);
     }
 
     public HotkeyIndicatorSettings()

--- a/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
+++ b/src/LiveSplit.HotkeyIndicator/HotkeyIndicatorSettings.cs
@@ -44,7 +44,7 @@ public partial class HotkeyIndicatorSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.HotkeyIndicator/LiveSplit.HotkeyIndicator.csproj
+++ b/src/LiveSplit.HotkeyIndicator/LiveSplit.HotkeyIndicator.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
